### PR TITLE
use `ahash` crate directly instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["egui", "raster", "software", "render", "softbuffer"]
 egui = { version = "0.34", default-features = false }
 strength_reduce = "0.2.4"
 constify = { path = "constify", version = "0.0.1" }
-ahash = { version = "0.8.12", default-features = false, features = ["no-rng"] }
+ahash = { version = "0.8", default-features = false, features = ["no-rng"] }
 
 rayon = { version = "1.11.0", optional = true }
 log = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ keywords = ["egui", "raster", "software", "render", "softbuffer"]
 [dependencies]
 egui = { version = "0.34", default-features = false }
 strength_reduce = "0.2.4"
-constify = { path = "constify", version = "0.0.1"}
+constify = { path = "constify", version = "0.0.1" }
+ahash = { version = "0.8.12", default-features = false, features = ["no-rng"] }
 
 rayon = { version = "1.11.0", optional = true }
 log = { version = "0.4", optional = true }
-winit = {version = "0.30", optional = true }
+winit = { version = "0.30", optional = true }
 softbuffer = { version = "0.4", optional = true }
-egui-winit = { version = "0.34", default-features = false, optional = true}
+egui-winit = { version = "0.34", default-features = false, optional = true }
 bytemuck = { version = "1.25", optional = true }
 
 # Optional dependencies for automated testing:
@@ -56,7 +57,7 @@ members = ["constify"]
 [features]
 default = ["std", "winit"]
 
-std = []
+std = ["ahash/std"]
 
 ## Turn on the `log` feature, that makes egui_software_backend log some errors using the [`log`](https://docs.rs/log) crate.
 log = ["dep:log"]
@@ -141,11 +142,11 @@ dbg_macro = "warn"
 debug_assert_with_mut_call = "warn"
 default_union_representation = "warn"
 derive_partial_eq_without_eq = "warn"
-disallowed_macros = "warn"                  # See clippy.toml
-disallowed_methods = "warn"                 # See clippy.toml
-disallowed_names = "warn"                   # See clippy.toml
-disallowed_script_idents = "warn"           # See clippy.toml
-disallowed_types = "warn"                   # See clippy.toml
+disallowed_macros = "warn"                   # See clippy.toml
+disallowed_methods = "warn"                  # See clippy.toml
+disallowed_names = "warn"                    # See clippy.toml
+disallowed_script_idents = "warn"            # See clippy.toml
+disallowed_types = "warn"                    # See clippy.toml
 doc_link_with_quotes = "warn"
 doc_markdown = "warn"
 empty_enum = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,9 @@ use core::ops::Range;
 
 use alloc::{borrow::Cow, vec, vec::Vec};
 
-use egui::{Color32, Mesh, Pos2, Vec2, ahash::HashMap, vec2};
+use egui::{Color32, Mesh, Pos2, Vec2, vec2};
+
+use ahash::HashMap;
 
 #[cfg(feature = "raster_stats")]
 use crate::stats::RasterStats;

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,7 +9,8 @@ use crate::{
     },
     raster::{rect::draw_rect, tri::draw_tri},
 };
-use egui::{Pos2, Vec2, ahash::HashMap, epaint::Vertex, vec2};
+use ahash::HashMap;
+use egui::{Pos2, Vec2, epaint::Vertex, vec2};
 
 #[allow(clippy::too_many_arguments)]
 pub fn draw_egui_mesh<const SUBPIX_BITS: i32>(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,7 +1,7 @@
 use crate::alloc::string::ToString;
+use ahash::HashMap;
 use alloc::format;
 use alloc::vec::Vec;
-use egui::ahash::HashMap;
 use std::time::Instant;
 
 #[allow(unused_imports)]


### PR DESCRIPTION
simply makes the `ahash` crate a dependency instead of relying on `egui` exporting it, as `egui::ahash` was deprecated, and is now removed as of https://github.com/emilk/egui/commit/1cd89b5edcbaa3ab6080e9d00e760492a0d30be1

still using the same exact `ahash` version and feature flags that egui currently uses

<img width="956" height="95" alt="image" src="https://github.com/user-attachments/assets/7d534f12-9402-4e65-9789-c33e848ec027" />
