### PR TITLE
Remove implementation of Eq from Vec4 (and add a nix devshell)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .idea
 
 Cargo.lock
+
+# nix stuff
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1779419951,
+        "narHash": "sha256-dMX0PUslUHPajP6o8FEoRdFv9afq/dec4POR0vVfjK4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "5b5c521d6cae9ef4aa32f888eb2c0ce595c9be52",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "development shell for egui_software_backend";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url  = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+  flake-utils.lib.eachDefaultSystem (system:
+  let
+    overlays = [ (import rust-overlay) ];
+
+    pkgs = import nixpkgs {
+      inherit system overlays;
+    };
+
+    librarys = with pkgs; [
+      # required by winit
+      libxkbcommon
+      wayland
+      libx11
+    ];
+  in
+  {
+    devShells.default = with pkgs; mkShell {
+      buildInputs = [
+        rust-bin.stable.latest.default
+        rust-analyzer
+        pkg-config
+        cargo-deny
+      ];
+
+      LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath librarys}";
+    };
+  });
+}

--- a/src/math/vec4.rs
+++ b/src/math/vec4.rs
@@ -288,8 +288,6 @@ impl core::ops::IndexMut<usize> for Vec4 {
     }
 }
 
-impl Eq for Vec4 {}
-
 impl Neg for Vec4 {
     type Output = Self;
 


### PR DESCRIPTION
Removed the implementation of `std::cmp::Eq` from `crate::math::vec4::Vec4`. Also added a nix flake with a devshell, can just drop that commit if you do not want it.

Reasoning for removing the `Eq` impl is that Vec4 does not fit the requirements to be `Eq`, as it is not reflexive around equality. What this means is that you cannot guarantee that `v == v` for all `v` where `v` is a `Vec4`. This is because IEEE 754 floating point spec specifies that `NaN != NaN`.

`PartialEq` is made for specifically this case, where the types equality relation is both symmetric and transitive, but not reflexive.

Relevant relation types:
- symmetric: `a == b` implies `b == a` and `a != b` implies `!(a == b)`
- transitive: `a == b` and `b == c` implies `a == c`
- reflexive: `a == a` for all `a`

So essentially, you cant have a struct with an `f32` that implements `Eq`.

Does this effect anything at all? I don't think so, its just a compiler hint really, but it is a logic error to implement it here.

Ran all tests and did a quick visual check of the examples, no issues.

The rust docs on `Eq` and `PartialEq`, as well as the wikipedia page on IEEE 754 floating point are interesting reading if you want to learn more:
- [Eq - rust docs](<https://doc.rust-lang.org/std/cmp/trait.Eq.html>)
- [PartialEq - rust docs](<https://doc.rust-lang.org/std/cmp/trait.PartialEq.html>)
- [IEEE 754 - wikipedia](<https://en.wikipedia.org/wiki/IEEE_754>)

sidenote: very cool repo :D, i was skimming through it to see the general shape of a egui software backend because i would like to add egui to my software renderer eventually

uhh yeah, ignore this pr if you dont care, i dont mind lol