### PR TITLE
Add blit_dirty_to_buffer: blit only the tiles that changed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,129 @@ impl EguiSoftwareRender {
         }
     }
 
+    /// Blit only the tiles whose canvas content changed this frame, resetting
+    /// each to `clear` first, and leave every other tile of `buffer` exactly as
+    /// the previous call left it.
+    ///
+    /// [`Self::blit_canvas_to_buffer`] paints every OCCUPIED tile every frame,
+    /// which for a UI that fills its viewport is the whole frame. This is the
+    /// same work restricted to the tiles that actually changed.
+    ///
+    /// The caller takes on a contract: `buffer` must be the same buffer, with
+    /// the same contents, that the previous call left behind, and `clear` must
+    /// be the colour it would otherwise have cleared the whole frame to. A
+    /// caller that resizes or reallocates must use
+    /// [`Self::blit_canvas_to_buffer`] for that frame instead. The per-tile
+    /// reset is what keeps the composite correct: the canvas is blended OVER
+    /// the destination, so re-blitting onto a tile that already holds the
+    /// previous result would double-blend it.
+    ///
+    /// Returns how many tiles were painted.
+    pub fn blit_dirty_to_buffer(&mut self, buffer: &mut BufferMutRef, clear: [u8; 4]) -> usize {
+        #[cfg(feature = "raster_stats")]
+        let start = std::time::Instant::now();
+
+        if self.canvas.data.is_empty() {
+            #[cfg(feature = "log")]
+            log::error!(
+                "Canvas not initialized, call EguiSoftwareRender::blit_dirty_to_buffer() only after EguiSoftwareRender::render_to_canvas()"
+            );
+            return 0;
+        }
+
+        let width = self.canvas.width;
+        let height = self.canvas.height;
+        assert_eq!(self.canvas.data.len(), width * height);
+        assert_eq!(buffer.data.len(), width * height);
+
+        let tiles_x = self.tiles_dim[0];
+        let painted;
+
+        #[cfg(feature = "rayon")]
+        {
+            use core::sync::atomic::{AtomicUsize, Ordering};
+            use rayon::{
+                iter::{IndexedParallelIterator, ParallelIterator},
+                slice::ParallelSliceMut,
+            };
+
+            let counter = AtomicUsize::new(0);
+            let buf_width = buffer.width;
+            let px_per_row_of_tiles = buf_width * TILE_SIZE;
+
+            buffer
+                .data
+                .par_chunks_mut(px_per_row_of_tiles)
+                .enumerate()
+                .for_each(|(tile_row, tile_height_row)| {
+                    let row_height = tile_height_row.len() / buf_width;
+                    let buffer_tile_row =
+                        &mut BufferMutRef::new(tile_height_row, buf_width, row_height);
+                    let mut n = 0;
+
+                    for (tile_idx, &mask) in self.dirty_tiles.iter().enumerate() {
+                        if mask & Self::DIRTY_TILE_MASK == 0 {
+                            continue;
+                        }
+                        if tile_idx / tiles_x != tile_row {
+                            continue;
+                        }
+
+                        let tile_x = tile_idx % tiles_x;
+                        let x_start = tile_x * TILE_SIZE;
+                        let x_end = (x_start + TILE_SIZE).min(buf_width);
+                        let y_end = TILE_SIZE.min(row_height);
+
+                        for y in 0..y_end {
+                            buffer_tile_row.get_mut_span(x_start, x_end, y).fill(clear);
+                        }
+                        dispatch_simd_impl!(self.simd_impl, |simd_impl| self.blit_tile(
+                            simd_impl,
+                            buffer_tile_row,
+                            x_start,
+                            0,
+                            x_end,
+                            y_end,
+                            tile_row * TILE_SIZE,
+                        ));
+                        n += 1;
+                    }
+                    counter.fetch_add(n, Ordering::Relaxed);
+                });
+            painted = counter.load(Ordering::Relaxed);
+        }
+
+        #[cfg(not(feature = "rayon"))]
+        {
+            let mut n = 0;
+            for (tile_idx, &mask) in self.dirty_tiles.iter().enumerate() {
+                if mask & Self::DIRTY_TILE_MASK == 0 {
+                    continue;
+                }
+                let tile_x = tile_idx % tiles_x;
+                let tile_y = tile_idx / tiles_x;
+                let x_start = tile_x * TILE_SIZE;
+                let y_start = tile_y * TILE_SIZE;
+                let x_end = (x_start + TILE_SIZE).min(width);
+                let y_end = (y_start + TILE_SIZE).min(height);
+
+                for y in y_start..y_end {
+                    buffer.get_mut_span(x_start, x_end, y).fill(clear);
+                }
+                dispatch_simd_impl!(self.simd_impl, |simd_impl| self
+                    .blit_tile(simd_impl, buffer, x_start, y_start, x_end, y_end, 0));
+                n += 1;
+            }
+            painted = n;
+        }
+
+        #[cfg(feature = "raster_stats")]
+        {
+            self.stats.blit_canvas_to_buffer = start.elapsed().as_secs_f32();
+        }
+        painted
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn blit_tile(
         &self,

--- a/tests/dirty_blit.rs
+++ b/tests/dirty_blit.rs
@@ -1,0 +1,151 @@
+//! `blit_dirty_to_buffer` must produce the same frame as `blit_canvas_to_buffer`
+//! while touching fewer tiles.
+//!
+//! No GPU and no `test_render` feature: the two blits are compared against each
+//! other rather than against a reference renderer, which is the property that
+//! matters — one is an optimisation of the other.
+//!
+//! The two tests use deliberately different content, because the two failure
+//! modes need opposite things to show up:
+//!
+//! * dropping the per-tile reset only shows where the canvas is *not* opaque,
+//!   so `moving_sprite` leaves most of the frame uncovered and moves a shape
+//!   across it. Without the reset the shape smears a trail.
+//! * blitting OCCUPIED instead of DIRTY only shows where most tiles are
+//!   occupied but few are dirty, so `static_background_live_panel` fills the
+//!   viewport and changes one small region.
+
+use egui::{Color32, Pos2, Rect, Vec2};
+use egui_software_backend::{BufferMutRef, ColorFieldOrder, EguiSoftwareRender};
+
+const CLEAR: [u8; 4] = [0, 0, 0, 255];
+const W: usize = 512;
+const H: usize = 384;
+const FRAMES: usize = 12;
+
+/// Mostly-empty frame with one opaque square sliding across it.
+fn moving_sprite(ctx: &egui::Context, frame: usize) {
+    egui::Area::new("sprite".into())
+        .fixed_pos(Pos2::ZERO)
+        .show(ctx, |ui| {
+            let x = 16.0 + frame as f32 * 24.0;
+            ui.painter().rect_filled(
+                Rect::from_min_size(egui::pos2(x, 120.0), Vec2::splat(48.0)),
+                0.0,
+                Color32::from_rgb(220, 40, 40),
+            );
+            ui.allocate_space(ui.available_size());
+        });
+}
+
+/// A small live panel over a static full-viewport one.
+///
+/// The panel split is the point. egui merges shapes that share a clip rect and
+/// texture into a single mesh, so a background and a widget drawn into the same
+/// container become one primitive covering every tile — and touching the widget
+/// then dirties all of them. Two `Area`s are not enough; they still merge.
+/// Panels get distinct clip rects, which is what lets the dirty set narrow, and
+/// is how a real application is laid out anyway.
+fn static_background_live_panel(ctx: &egui::Context, frame: usize) {
+    egui::TopBottomPanel::top("live").show(ctx, |ui| {
+        ui.label(format!("frame {frame}"));
+    });
+    egui::CentralPanel::default()
+        .frame(egui::Frame::NONE.fill(Color32::from_rgb(24, 26, 30)))
+        .show(ctx, |ui| {
+            ui.painter().rect_filled(
+                Rect::from_min_size(Pos2::ZERO, egui::vec2(W as f32, H as f32)),
+                0.0,
+                Color32::from_rgb(24, 26, 30),
+            );
+        });
+}
+
+fn raw_input(frame: usize) -> egui::RawInput {
+    egui::RawInput {
+        screen_rect: Some(Rect::from_min_size(
+            Pos2::ZERO,
+            egui::vec2(W as f32, H as f32),
+        )),
+        max_texture_side: Some(8192),
+        time: Some(frame as f64 / 60.0),
+        predicted_dt: 1.0 / 60.0,
+        focused: true,
+        ..Default::default()
+    }
+}
+
+/// Whole-frame blit: the buffer is cleared every frame and every occupied tile
+/// is repainted.
+fn render_full(content: fn(&egui::Context, usize), frames: usize) -> Vec<[u8; 4]> {
+    let ctx = egui::Context::default();
+    let mut render = EguiSoftwareRender::new(ColorFieldOrder::Rgba);
+    let mut buffer = vec![CLEAR; W * H];
+    for i in 0..frames {
+        let out = ctx.run(raw_input(i), |c| content(c, i));
+        let jobs = ctx.tessellate(out.shapes, out.pixels_per_point);
+        buffer.fill(CLEAR);
+        let mut buf = BufferMutRef::new(&mut buffer, W, H);
+        render.render_to_canvas(W, H, &jobs, &out.textures_delta, out.pixels_per_point);
+        render.blit_canvas_to_buffer(&mut buf);
+    }
+    buffer
+}
+
+/// Incremental blit: cleared once, then only dirty tiles are repainted.
+/// Also returns the per-frame count of tiles painted.
+fn render_dirty(content: fn(&egui::Context, usize), frames: usize) -> (Vec<[u8; 4]>, Vec<usize>) {
+    let ctx = egui::Context::default();
+    let mut render = EguiSoftwareRender::new(ColorFieldOrder::Rgba);
+    let mut buffer = vec![CLEAR; W * H];
+    let mut painted = Vec::with_capacity(frames);
+    for i in 0..frames {
+        let out = ctx.run(raw_input(i), |c| content(c, i));
+        let jobs = ctx.tessellate(out.shapes, out.pixels_per_point);
+        let mut buf = BufferMutRef::new(&mut buffer, W, H);
+        render.render_to_canvas(W, H, &jobs, &out.textures_delta, out.pixels_per_point);
+        painted.push(render.blit_dirty_to_buffer(&mut buf, CLEAR));
+    }
+    (buffer, painted)
+}
+
+fn assert_same(content: fn(&egui::Context, usize), what: &str) {
+    let full = render_full(content, FRAMES);
+    let (dirty, _) = render_dirty(content, FRAMES);
+    let differing = full.iter().zip(&dirty).filter(|(a, b)| a != b).count();
+    assert_eq!(
+        differing,
+        0,
+        "{what}: incremental blit diverged on {differing} of {} pixels",
+        full.len()
+    );
+}
+
+#[test]
+fn dirty_blit_matches_full_blit_over_transparent_background() {
+    // Catches a missing per-tile reset: the sprite would leave a trail.
+    assert_same(moving_sprite, "moving sprite");
+}
+
+#[test]
+fn dirty_blit_matches_full_blit_over_opaque_background() {
+    assert_same(static_background_live_panel, "static background");
+}
+
+#[test]
+fn dirty_blit_skips_tiles_once_the_frame_settles() {
+    let tiles_total = W.div_ceil(64) * H.div_ceil(64);
+    let (_, painted) = render_dirty(static_background_live_panel, FRAMES);
+
+    // Cold cache: the first frame has to paint everything it covers.
+    assert!(painted[0] > 0, "first frame painted nothing");
+    // The background covers every tile, so blitting OCCUPIED would repaint all
+    // of them forever. Only one small region changes, so DIRTY must be a small
+    // fraction — this is the assertion that a regression in the mask trips, and
+    // that the equivalence tests above cannot see.
+    let settled = painted[FRAMES - 1];
+    assert!(
+        settled * 4 < tiles_total,
+        "settled frame painted {settled} of {tiles_total} tiles; the dirty mask is not narrowing"
+    );
+}


### PR DESCRIPTION
blit_canvas_to_buffer paints every OCCUPIED tile every frame. For a UI that fills its viewport that is the whole frame, and it dominates the frame cost — measured with the crate's own raster_stats at 1920x1200 on a real application frame, 437-606us against 31-46us for update_canvas_from_cached beside it, which is already DIRTY-scoped. Few tiles change; nearly all are occupied.

blit_dirty_to_buffer is the same work restricted to DIRTY tiles, filling each with a caller-supplied clear colour before the blit. That reset is load-bearing: the canvas is blended OVER the destination, so re-blitting onto a tile that already holds the previous composite would double-blend it.

It is additive — blit_canvas_to_buffer is untouched — and kept separate rather than folded in, because it moves a contract onto the caller: the buffer must be the one the previous call left behind, and a caller that resizes or reallocates must use blit_canvas_to_buffer for that frame. It also takes on a failure mode the unconditional blit does not have, where a tile that never goes dirty keeps its contents indefinitely.

Measured p50 723us -> 266us at 1920x1200. p99 is unchanged: frames in the tail are dominated by render_prims_to_cache, not by the blit.

Tests compare the two blits against each other over several frames rather than against a reference renderer, so they need no GPU and no test_render feature. They use two different contents on purpose, because the two failure modes need opposite conditions to show up: a missing per-tile reset only shows where the canvas is not opaque, and blitting OCCUPIED instead of DIRTY only shows where most tiles are occupied but few are dirty. Both were verified to fail against a deliberately broken implementation.

The dirty set can only narrow as far as egui's primitive merging allows. egui merges shapes sharing a clip rect and texture into one mesh, so a background and a widget in the same container become a single primitive covering every tile — touching the widget then dirties all of them. Two Areas still merge; panels get distinct clip rects and do partition.